### PR TITLE
Add web interface to publish FuseSoC core from GitHub repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 local_settings.py
 db.sqlite3
 
+# collected static files
+/staticfiles/
+
 # Virtual Environment
 .env
 venv/

--- a/core_directory/static/js/publish_core_from_github.js
+++ b/core_directory/static/js/publish_core_from_github.js
@@ -1,0 +1,508 @@
+let lastValidatedCore = null; // { blob, filename }
+
+document.addEventListener('DOMContentLoaded', function() {
+
+    /**
+     * Extracts owner and repo from a GitHub URL.
+     * @param {string} url
+     * @returns {{owner: string, repo: string}|null}
+     */
+    function getOwnerRepo(url) {
+        var match = url.match(/^https?:\/\/github\.com\/([^\/]+)\/([^\/]+?)(?:\.git)?\/?$/);
+        if (!match) return null;
+        return { owner: match[1], repo: match[2] };
+    }
+
+    /**
+     * Renders the result area with repository and core file info.
+     * @param {object} obj
+     */
+    function showResult(obj) {
+        const resultDiv = document.getElementById('result');
+        if (obj.error) {
+            resultDiv.innerHTML = `<div class="alert alert-danger">${obj.error}</div>`;
+            return;
+        }
+        let html = '';
+        if (obj.repo) {
+            html += `
+            <div class="card mb-3">
+            ${getCardHeaderHtml("bi-github", "Repository details")}
+            <div class="card-body">
+                <h5 class="card-title">
+                <a href="${obj.repo.url}" target="_blank">${obj.repo.name}</a>
+                </h5>
+                <p class="card-text">${obj.repo.description || ''}</p>
+                <p class="card-text">
+                <span class="me-3">⭐ ${obj.repo.stars}</span>
+                <span>🍴 ${obj.repo.forks}</span>
+                </p>
+            </div>
+            </div>
+            `;
+        }
+        if (obj.core_files) {
+            html += `${getCardHeaderHtml("bi-boxes", "Available cores")}`;
+            if (obj.core_files.length > 0) {
+                html += `
+                    <div class="input-group mb-3">
+                        <select id="core-file-select" class="form-select">
+                            ${obj.core_files.map(f => `<option value="${f}">${f}</option>`).join('')}
+                        </select>
+                        <button id="validate-core-btn" type="button" class="btn btn-primary">Validate</button>
+                        <button id="publish-core-btn" type="button" class="btn btn-secondary" disabled>Publish</button>
+                    </div>
+                    <div id="validate-result" style="margin-top:1em;"></div>
+                `;
+            } else {
+                html +=                    
+                    `<div class="alert alert-warning">
+                        <strong>No <code>.core</code> files found in the repository.</strong><br>
+                        <span class="text-muted">
+                            Note: Only <code>.core</code> files located in the root of the repository can be published.
+                        </span>
+                    </div>`;  
+            }
+        }
+        // html += `<pre>${JSON.stringify(obj, null, 2)}</pre>`;
+        resultDiv.innerHTML = html;
+
+        // Add event listeners
+        const validateBtn = document.getElementById('validate-core-btn');
+        const publishBtn = document.getElementById('publish-core-btn');
+        const select = document.getElementById('core-file-select');
+
+        if (validateBtn) {
+            validateBtn.addEventListener('click', function() {
+                const coreFilePath = select.value;
+                validateCoreFile(obj, coreFilePath);
+            });
+        }
+        if (publishBtn) {
+            publishBtn.addEventListener('click', publishCoreFile);
+        }
+        if (select) {
+            select.addEventListener('change', function() {
+                // Clear validation result and disable publish when selection changes
+                document.getElementById('validate-result').innerHTML = '';
+                if (publishBtn) {
+                    publishBtn.disabled = true;
+                    publishBtn.classList.remove('btn-success');
+                    publishBtn.classList.add('btn-secondary');
+                }
+                lastValidatedCore = null;
+            });
+        }
+    }
+
+    /**
+     * Returns the card header HTML with the given title.
+     * @param {string} title
+     * @returns {string}
+     */
+    function getCardHeaderHtml(icon, title) {
+        let template = document.getElementById('card-header-template').innerHTML;
+        return template.replace(/__TITLE__/g, title).replace(/__ICON__/g, icon);
+    }
+
+    /**
+     * Clears the result display area.
+     */
+    function clearResult() {
+        document.getElementById('result').innerHTML = '';
+    }
+
+    /**
+     * Shows/hides tag and commit fields based on version type.
+     */
+    function toggleFields() {
+        const versionType = document.getElementById('version_type').value;
+        document.getElementById('tag-field').style.display = (versionType === 'tag') ? '' : 'none';
+        document.getElementById('commit-field').style.display = (versionType === 'commit') ? '' : 'none';
+    }
+
+    /**
+     * When the repo URL input loses focus (blur), fetch tags if "Tag" is selected.
+     */
+    document.getElementById('repo_url').addEventListener('blur', function() {
+        if (document.getElementById('version_type').value === 'tag') {
+            fetchTags();
+        }
+    });
+
+    /**
+     * When the version type changes, clear the result, update fields, and fetch tags if needed.
+     */
+    document.getElementById('version_type').addEventListener('change', function() {
+        clearResult();
+        toggleFields();
+        if (this.value === 'tag') {
+            fetchTags();
+        }
+    });
+
+    /**
+     * When the tag selection changes, clear the result.
+     */
+    document.getElementById('tag').addEventListener('change', clearResult);
+
+    /**
+     * When the commit input changes, clear the result.
+     */
+    document.getElementById('commit').addEventListener('input', clearResult);
+
+    /**
+     * When the repo URL input changes, clear the result.
+     */
+    document.getElementById('repo_url').addEventListener('input', clearResult);
+    /**
+     * Handles GitHub API error responses and rate limits.
+     * @param {object} data
+     * @param {string} defaultError
+     * @param {function} [showResultFn=showResult]
+     * @returns {boolean}
+     */
+    function handleGithubApiResponse(data, defaultError, showResultFn = showResult) {
+        if (data && data.message) {
+            if (data.message.includes('API rate limit exceeded')) {
+                showResultFn({ error: 'GitHub API rate limit exceeded. Please wait and try again later.' });
+            } else {
+                showResultFn({ error: `GitHub API error: ${data.message}` });
+            }
+            return false;
+        }
+        if (data === undefined || data === null) {
+            showResultFn({ error: defaultError });
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Fetches tags for the selected repository and populates the tag select.
+     */
+    function fetchTags() {
+        clearResult();
+        const repoUrl = document.getElementById('repo_url').value;
+        const info = getOwnerRepo(repoUrl);
+        const tagSelect = document.getElementById('tag');
+        tagSelect.innerHTML = '';
+        if (!info) {
+            tagSelect.innerHTML = '<option value="">Invalid URL</option>';
+            return;
+        }
+        fetch(`https://api.github.com/repos/${info.owner}/${info.repo}/tags`)
+            .then(response => response.json())
+            .then(data => {
+                if (!handleGithubApiResponse(data, 'Error fetching tags.')) return;
+                if (Array.isArray(data) && data.length > 0) {
+                    data.forEach(tag => {
+                        const option = document.createElement('option');
+                        option.value = tag.name;
+                        option.textContent = tag.name;
+                        tagSelect.appendChild(option);
+                    });
+                } else {
+                    tagSelect.innerHTML = '<option value="">No tags found</option>';
+                }
+            })
+            .catch(err => showResult({ error: 'Error fetching tags.' }));
+    }
+
+    /**
+     * Lists all .core files in the repo at the given SHA.
+     * @param {string} owner
+     * @param {string} repo
+     * @param {string} sha
+     * @returns {Promise<string[]>}
+     */
+    async function listCoreFiles(owner, repo, sha) {
+        const treeUrl = `https://api.github.com/repos/${owner}/${repo}/git/trees/${sha}?recursive=1`;
+        try {
+            const response = await fetch(treeUrl);
+            const data = await response.json();
+            if (!handleGithubApiResponse(data, 'Error listing .core files.')) return [];
+            if (!data.tree) return [];
+            return data.tree
+                .filter(item => 
+                    item.type === 'blob' && 
+                    item.path.endsWith('.core') &&
+                    !item.path.includes('/') // Only root files                
+                )
+                .map(item => item.path);
+        } catch (err) {
+            showResult({ error: 'Error listing .core files.' });
+            return [];
+        }
+    }
+
+    /**
+     * Validates the selected core file by sending it to the API.
+     * @param {object} obj
+     * @param {string} coreFilePath
+     */
+    async function validateCoreFile(obj, coreFilePath) {
+        const validateResultDiv = document.getElementById('validate-result');
+        const publishBtn = document.getElementById('publish-core-btn');
+        if (publishBtn) {
+            publishBtn.disabled = true;
+            publishBtn.classList.remove('btn-success');
+            publishBtn.classList.add('btn-secondary');
+        }
+        validateResultDiv.innerHTML = 'Validating...';
+
+        const rawUrl = `https://raw.githubusercontent.com/${obj.repo.name}/${obj.commit}/${coreFilePath}`;
+
+        let text;
+        try {
+            const response = await fetch(rawUrl);
+            if (!response.ok) {
+                if (response.status === 403) {
+                    let errMsg = 'Could not fetch core file from GitHub (403 Forbidden).';
+                    try {
+                        const errData = await response.json();
+                        if (errData && errData.message && errData.message.includes('API rate limit exceeded')) {
+                            errMsg = 'GitHub API rate limit exceeded. Please wait and try again later.';
+                        } else if (errData && errData.message) {
+                            errMsg = `GitHub API error: ${errData.message}`;
+                        }
+                    } catch {}
+                    validateResultDiv.innerHTML = `<div class="alert alert-danger">${errMsg}</div>`;
+                    return;
+                }
+                validateResultDiv.innerHTML = '<div class="alert alert-danger">Could not fetch core file from GitHub.</div>';
+                return;
+            }
+            text = await response.text();
+        } catch (err) {
+            validateResultDiv.innerHTML = '<div class="alert alert-danger">Error fetching core file.</div>';
+            return;
+        }
+
+        let coreObj;
+        try {
+            coreObj = jsyaml.load(text);
+        } catch (e) {
+            validateResultDiv.innerHTML = `<div class="alert alert-danger">Could not parse YAML: ${e}</div>`;
+            return;
+        }
+
+        if (coreObj && typeof coreObj === 'object' && 'provider' in coreObj) {
+            validateResultDiv.innerHTML =
+                `<div class="alert alert-warning">
+                    This .core file reffers to an external <code>provider</code> and therefore can not be uploaded via web interface<br>
+                    <strong>Reason:</strong> Only core files <b>without</b> a provider section are accepted. The .core file and its source files need to be located in the same repository.
+                    <strong>Hint:</strong> To publish core files reffering to a github in its provider section, please use the API directly.
+                </div>`;  
+              return;
+        }
+
+        // Add provider section
+        const [owner, repo] = obj.repo.name.split('/');
+        coreObj.provider = {
+            name: "github",
+            user: owner,
+            repo: repo,
+            version: obj.commit
+        };
+
+        const newYaml = jsyaml.dump(coreObj);
+
+        const blob = new Blob([newYaml], { type: "application/x-yaml" });
+
+        const formData = new FormData();
+        formData.append('core_file', blob, coreFilePath);
+
+        let validateResponse, respText, result;
+        try {
+            validateResponse = await fetch('/api/v1/validate/', {
+                method: 'POST',
+                body: formData,
+                credentials: 'same-origin',
+            });
+            respText = await validateResponse.text();
+            try {
+                result = JSON.parse(respText);
+            } catch {
+                result = respText;
+            }
+        } catch (err) {
+            validateResultDiv.innerHTML = '<div class="alert alert-danger">Error during validation.</div>';
+            return;
+        }
+
+        if (validateResponse.ok) {
+            lastValidatedCore = { blob, filename: coreFilePath };
+            validateResultDiv.innerHTML =
+                `<div class="alert alert-success">
+                    Validation successful!<br>
+                    <pre>${JSON.stringify(result, null, 2)}</pre>
+                </div>`;
+            if (publishBtn) {
+                publishBtn.disabled = false;
+                publishBtn.classList.remove('btn-secondary');
+                publishBtn.classList.add('btn-success');
+            }
+        } else {
+            lastValidatedCore = null;
+            let errorMsg = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
+            validateResultDiv.innerHTML =
+                `<div class="alert alert-danger">Validation failed:<br><pre>${errorMsg}</pre></div>`;
+            if (publishBtn) {
+                publishBtn.disabled = true;
+                publishBtn.classList.remove('btn-success');
+                publishBtn.classList.add('btn-secondary');
+            }
+        }
+    }
+
+    /**
+     * Publishes the last validated core file to the API.
+     */
+    async function publishCoreFile() {
+        if (!lastValidatedCore) return;
+        const publishBtn = document.getElementById('publish-core-btn');
+        if (publishBtn) {
+            publishBtn.disabled = true;
+            publishBtn.classList.remove('btn-success');
+            publishBtn.classList.add('btn-secondary');
+        }
+        document.getElementById('validate-result').innerHTML = 'Publishing...';
+
+        const formData = new FormData();
+        formData.append('core_file', lastValidatedCore.blob, lastValidatedCore.filename);
+
+        try {
+            const publishResponse = await fetch('/api/v1/publish/', {
+                method: 'POST',
+                body: formData,
+                credentials: 'same-origin',
+            });
+
+            const respText = await publishResponse.text();
+            let result;
+            try {
+                result = JSON.parse(respText);
+            } catch {
+                result = respText;
+            }
+
+            if (publishResponse.ok) {
+                document.getElementById('validate-result').innerHTML =
+                    `<div class="alert alert-success">Publish successful!<br><pre>${JSON.stringify(result, null, 2)}</pre></div>`;
+            } else {
+                document.getElementById('validate-result').innerHTML =
+                    `<div class="alert alert-danger">Publish failed:<br><pre>${JSON.stringify(result, null, 2)}</pre></div>`;
+            }
+        } catch (err) {
+            document.getElementById('validate-result').innerHTML = 'Error during publish.';
+        }
+    }
+
+    // --- Main Form Submission ---
+
+    document.getElementById('repo-form').addEventListener('submit', function(e) {
+        e.preventDefault();
+        clearResult();
+
+        const repoUrl = document.getElementById('repo_url').value;
+        const versionType = document.getElementById('version_type').value;
+        const info = getOwnerRepo(repoUrl);
+
+        if (!info) {
+            showResult({ error: 'Invalid GitHub URL.' });
+            return;
+        }
+
+        fetch(`https://api.github.com/repos/${info.owner}/${info.repo}`)
+            .then(response => response.json())
+            .then(repoData => {
+                if (!handleGithubApiResponse(repoData, 'Repository not found.')) return;
+
+                function processSha(sha, extra) {
+                    listCoreFiles(info.owner, info.repo, sha)
+                        .then(coreFiles => {
+                            showResult({
+                                repo: {
+                                    name: repoData.full_name,
+                                    description: repoData.description,
+                                    stars: repoData.stargazers_count,
+                                    forks: repoData.forks_count,
+                                    url: repoData.html_url,
+                                },
+                                ...extra,
+                                core_files: coreFiles,
+                            });
+                        })
+                        .catch(err => showResult({ error: 'Error listing .core files.' }));
+                }
+
+                if (versionType === 'latest') {
+                    fetch(`https://api.github.com/repos/${info.owner}/${info.repo}/commits`)
+                        .then(response => response.json())
+                        .then(data => {
+                            if (!handleGithubApiResponse(data, 'Error fetching latest commit.')) return;
+                            if (Array.isArray(data) && data.length > 0) {
+                                processSha(data[0].sha, {
+                                    type: 'latest',
+                                    commit: data[0].sha,
+                                    message: data[0].commit.message,
+                                });
+                            } else {
+                                showResult({ error: 'No commits found.' });
+                            }
+                        })
+                        .catch(err => showResult({ error: 'Error fetching latest commit.' }));
+
+                } else if (versionType === 'tag') {
+                    const tag = document.getElementById('tag').value;
+                    if (!tag) {
+                        showResult({ error: 'No tag selected.' });
+                        return;
+                    }
+                    fetch(`https://api.github.com/repos/${info.owner}/${info.repo}/tags`)
+                        .then(response => response.json())
+                        .then(data => {
+                            if (!handleGithubApiResponse(data, 'Error fetching tags.')) return;
+                            const tagObj = Array.isArray(data) ? data.find(t => t.name === tag) : null;
+                            if (tagObj) {
+                                processSha(tagObj.commit.sha, {
+                                    type: 'tag',
+                                    tag: tag,
+                                    commit: tagObj.commit.sha,
+                                });
+                            } else {
+                                showResult({ error: 'Tag not found.' });
+                            }
+                        })
+                        .catch(err => showResult({ error: 'Error fetching tag info.' }));
+
+                } else if (versionType === 'commit') {
+                    const commit = document.getElementById('commit').value;
+                    if (!commit) {
+                        showResult({ error: 'Please enter a commit hash.' });
+                        return;
+                    }
+                    fetch(`https://api.github.com/repos/${info.owner}/${info.repo}/commits/${commit}`)
+                        .then(response => response.json())
+                        .then(data => {
+                            if (!handleGithubApiResponse(data, 'Error fetching commit info.')) return;
+                            if (data && data.sha) {
+                                processSha(data.sha, {
+                                    type: 'commit',
+                                    commit: data.sha,
+                                    message: data.commit.message,
+                                });
+                            } else {
+                                showResult({ error: 'Commit not found.' });
+                            }
+                        })
+                        .catch(err => showResult({ error: 'Error fetching commit info.' }));
+                }
+            })
+            .catch(err => showResult({ error: 'Error fetching repository details.' }));
+        toggleFields();
+    });
+
+    toggleFields();
+});

--- a/core_directory/templates/web_ui/core_publish.html
+++ b/core_directory/templates/web_ui/core_publish.html
@@ -19,31 +19,36 @@
     <div class="card shadow-sm mb-4">
         {% include "web_ui/includes/card_header.html" with icon="bi bi-box" title="Publish new core" %}
         <div class="card-body">
-            <form id="repo-form" autocomplete="off" class="row g-2 align-items-center">
-                <div class="col-auto">
-                    <label for="repo_url" class="visually-hidden">GitHub Repository URL</label>
-                    <input type="url" id="repo_url" name="repo_url" class="form-control" style="min-width:350px; width:400px;" required placeholder="https://github.com/owner/repo">
+            <div class="card shadow-sm mb-3">           
+                {% include "web_ui/includes/card_header.html" with icon="bi bi-shop" title="Select GitHub repository" %}
+                <div class="p-3">
+                    <form id="repo-form" autocomplete="off" class="row g-2 align-items-center">
+                        <div class="col-auto">
+                            <label for="repo_url" class="visually-hidden">GitHub Repository URL</label>
+                            <input type="url" id="repo_url" name="repo_url" class="form-control" style="min-width:350px; width:400px;" required placeholder="https://github.com/owner/repo">
+                        </div>
+                        <div class="col-auto">
+                            <label for="version_type" class="visually-hidden">Version Type</label>
+                            <select id="version_type" name="version_type" class="form-select" required>
+                                <option value="tag">Tag</option>
+                                <option value="latest">Latest</option>
+                                <option value="commit">Commit</option>
+                            </select>
+                        </div>
+                        <div class="col-auto" id="tag-field" style="display:none;">
+                            <label for="tag" class="visually-hidden">Tag</label>
+                            <select id="tag" name="tag" class="form-select"></select>
+                        </div>
+                        <div class="col-auto" id="commit-field" style="display:none;">
+                            <label for="commit" class="visually-hidden">Commit Hash</label>
+                            <input type="text" id="commit" name="commit" class="form-control" placeholder="e.g. 1a2b3c4d">
+                        </div>
+                        <div class="col-auto">
+                            <button type="submit" class="btn btn-primary">Parse</button>
+                        </div>
+                    </form>
                 </div>
-                <div class="col-auto">
-                    <label for="version_type" class="visually-hidden">Version Type</label>
-                    <select id="version_type" name="version_type" class="form-select" required>
-                        <option value="tag">Tag</option>
-                        <option value="latest">Latest</option>
-                        <option value="commit">Commit</option>
-                    </select>
-                </div>
-                <div class="col-auto" id="tag-field" style="display:none;">
-                    <label for="tag" class="visually-hidden">Tag</label>
-                    <select id="tag" name="tag" class="form-select"></select>
-                </div>
-                <div class="col-auto" id="commit-field" style="display:none;">
-                    <label for="commit" class="visually-hidden">Commit Hash</label>
-                    <input type="text" id="commit" name="commit" class="form-control" placeholder="e.g. 1a2b3c4d">
-                </div>
-                <div class="col-auto">
-                    <button type="submit" class="btn btn-primary">Parse</button>
-                </div>
-            </form>
+            </div>
             <div id="result"></div>
         </div>
     </div>

--- a/core_directory/templates/web_ui/core_publish.html
+++ b/core_directory/templates/web_ui/core_publish.html
@@ -1,0 +1,52 @@
+{% extends "web_ui/base.html" %}
+{% load static %}
+{% block title_suffix %}| Publish core{% endblock %}
+{% block extra_head %}
+    <script src="{% static 'js/expandable_section.js' %}"></script>
+    <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js"></script>
+    <style>
+        label { display: block; margin-top: 1em; }
+        .hidden { display: none; }
+        #result { margin-top: 2em; }
+    </style>
+{% endblock %}
+{% block content %}
+    <!-- Hidden card header template for JS use -->
+    <div id="card-header-template" style="display:none;">
+        {% include "web_ui/includes/card_header.html" with icon="bi __ICON__" title="__TITLE__" %}
+    </div>
+
+    <div class="card shadow-sm mb-4">
+        {% include "web_ui/includes/card_header.html" with icon="bi bi-box" title="Publish new core" %}
+        <div class="card-body">
+            <form id="repo-form" autocomplete="off" class="row g-2 align-items-center">
+                <div class="col-auto">
+                    <label for="repo_url" class="visually-hidden">GitHub Repository URL</label>
+                    <input type="url" id="repo_url" name="repo_url" class="form-control" style="min-width:350px; width:400px;" required placeholder="https://github.com/owner/repo">
+                </div>
+                <div class="col-auto">
+                    <label for="version_type" class="visually-hidden">Version Type</label>
+                    <select id="version_type" name="version_type" class="form-select" required>
+                        <option value="tag">Tag</option>
+                        <option value="latest">Latest</option>
+                        <option value="commit">Commit</option>
+                    </select>
+                </div>
+                <div class="col-auto" id="tag-field" style="display:none;">
+                    <label for="tag" class="visually-hidden">Tag</label>
+                    <select id="tag" name="tag" class="form-select"></select>
+                </div>
+                <div class="col-auto" id="commit-field" style="display:none;">
+                    <label for="commit" class="visually-hidden">Commit Hash</label>
+                    <input type="text" id="commit" name="commit" class="form-control" placeholder="e.g. 1a2b3c4d">
+                </div>
+                <div class="col-auto">
+                    <button type="submit" class="btn btn-primary">Parse</button>
+                </div>
+            </form>
+            <div id="result"></div>
+        </div>
+    </div>
+    
+    <script src="{% static 'js/publish_core_from_github.js' %}"></script>
+{% endblock %}

--- a/core_directory/templates/web_ui/core_publish.html
+++ b/core_directory/templates/web_ui/core_publish.html
@@ -17,7 +17,7 @@
     </div>
 
     <div class="card shadow-sm mb-4">
-        {% include "web_ui/includes/card_header.html" with icon="bi bi-box" title="Publish new core" %}
+        {% include "web_ui/includes/card_header.html" with icon="bi bi-cloud-plus" title="Publish new core" %}
         <div class="card-body">
             <div class="card shadow-sm mb-3">           
                 {% include "web_ui/includes/card_header.html" with icon="bi bi-shop" title="Select GitHub repository" %}

--- a/core_directory/templates/web_ui/core_publish.html
+++ b/core_directory/templates/web_ui/core_publish.html
@@ -38,11 +38,14 @@
                             <li>Select the core you like to publish, validate it, and then publish.</li>
                         </ol>
                         <p>
-                            Make sure the repository you specify actually contains the core and its source files - not just a core description file that points to another provider.
-                            Cores with a <code>provider</code> section referencing a different repository cannot be published here; use the <a href="{% url 'core_directory:api_docs_landing' %}" target="_blank">API</a> for those cases.
+                            Make sure the repository you specify actually contains the local core with its source files - not just a core description file that points to another provider.
+                            External cores already containing a <code>provider</code> section cannot be published here; use the <a href="{% url 'core_directory:api_docs_landing' %}" target="_blank">API</a> in those cases.
                         </p>
                         <p>
-                            <strong>Note:</strong> When publishing, a <code>provider</code> section will automatically be added to the core, referencing the selected GitHub commit by its SHA.
+                            <strong>Note:</strong> When publishing using this web interface, the core will automatically be converted into an remote core. A <code>provider</code> section will be added to the core, referencing the selected GitHub commit by its SHA.
+                        </p>
+                        <p>
+                            <strong>Core signing is not supported:</strong> This web interface does not currently support signing of published cores or publishing of existing signatures.
                         </p>
                     </div>
                 </div>

--- a/core_directory/templates/web_ui/core_publish.html
+++ b/core_directory/templates/web_ui/core_publish.html
@@ -30,8 +30,8 @@
                         <div class="col-auto">
                             <label for="version_type" class="visually-hidden">Version Type</label>
                             <select id="version_type" name="version_type" class="form-select" required>
-                                <option value="tag">Tag</option>
                                 <option value="latest">Latest</option>
+                                <option value="tag">Tag</option>
                                 <option value="commit">Commit</option>
                             </select>
                         </div>

--- a/core_directory/templates/web_ui/core_publish.html
+++ b/core_directory/templates/web_ui/core_publish.html
@@ -19,6 +19,33 @@
     <div class="card shadow-sm mb-4">
         {% include "web_ui/includes/card_header.html" with icon="bi bi-cloud-plus" title="Publish new core" %}
         <div class="card-body">
+                <div class="section-card mb-3 border rounded">
+                    <div class="section-header p-2 bg-light d-flex align-items-center" style="cursor:pointer;">
+                        <span class="expand-toggle me-2" aria-label="Expand/collapse library" tabindex="0">
+                            <i class="bi bi-plus"></i>
+                        </span>
+                        <strong>How to publish a FuseSoC Core</strong>
+                    </div>
+                    <div class="section-content p-3" style="display:none;">
+                        <p>
+                            Use this page to publish a FuseSoC core directly from a GitHub repository.<br>
+                            You can select the latest commit, a specific tag, or enter a commit hash to target a particular version.
+                            Only <code>.core</code> files located in the root of the repository are supported.
+                        </p>
+                        <ol>
+                            <li>Enter a GitHub repo URL and select a version (latest, tag, or commit).</li>
+                            <li>Parse to list available <code>.core</code> files.</li>
+                            <li>Select the core you like to publish, validate it, and then publish.</li>
+                        </ol>
+                        <p>
+                            Make sure the repository you specify actually contains the core and its source files - not just a core description file that points to another provider.
+                            Cores with a <code>provider</code> section referencing a different repository cannot be published here; use the <a href="{% url 'core_directory:api_docs_landing' %}" target="_blank">API</a> for those cases.
+                        </p>
+                        <p>
+                            <strong>Note:</strong> When publishing, a <code>provider</code> section will automatically be added to the core, referencing the selected GitHub commit by its SHA.
+                        </p>
+                    </div>
+                </div>
             <div class="card shadow-sm mb-3">           
                 {% include "web_ui/includes/card_header.html" with icon="bi bi-shop" title="Select GitHub repository" %}
                 <div class="p-3">

--- a/core_directory/templates/web_ui/landing.html
+++ b/core_directory/templates/web_ui/landing.html
@@ -48,6 +48,12 @@
                         <div class="stat-label"><i class="bi bi-box"></i> Cores</div>
                     </div>
                 </a>
+                <a href="{% url 'core-publish' %}" class="stat-card-link">
+                    <div class="stat-card">
+                        <div class="stat-value"><b><i class="bi bi-cloud-plus-fill"></i></b></div>
+                        <div class="stat-label">Publish Core</div>
+                    </div>
+                </a>
             </div>
         </div>
     </div>
@@ -67,7 +73,7 @@
         </div>
 
         <div class="desc-section">
-            <h2>Like to publish your cores?</h2>
+            <h2>Interested in publishing your core?</h2>
             <p>
                 The FuseSoC Package Directory supports several ways to publish your cores:
             </p>

--- a/core_directory/templates/web_ui/landing.html
+++ b/core_directory/templates/web_ui/landing.html
@@ -51,7 +51,7 @@
                 <a href="{% url 'core-publish' %}" class="stat-card-link">
                     <div class="stat-card">
                         <div class="stat-value"><b><i class="bi bi-cloud-plus-fill"></i></b></div>
-                        <div class="stat-label">Publish Core</div>
+                        <div class="stat-label">Publish core</div>
                     </div>
                 </a>
             </div>
@@ -73,7 +73,7 @@
         </div>
 
         <div class="desc-section">
-            <h2>Interested in publishing your core?</h2>
+            <h2>Interested in publishing your FuseSoC core?</h2>
             <p>
                 The FuseSoC Package Directory supports several ways to publish your cores:
             </p>

--- a/core_directory/templates/web_ui/landing.html
+++ b/core_directory/templates/web_ui/landing.html
@@ -58,12 +58,24 @@
                 The FuseSoC Package Directory is a searchable index of reusable hardware cores, IP blocks, and SoC components.
                 Browse, search, and integrate open source cores for your FPGA or ASIC projects, powered by <a href="https://fusesoc.github.io/" target="_blank">FuseSoC</a>.
             </p>
+            <div class="links-section mb-4">
+                <a href="https://fusesoc.github.io/" target="_blank"><i class="bi bi-book"></i> Documentation</a>
+                <a href="https://github.com/fusesoc/fusesoc-webserver" target="_blank"><i class="bi bi-github"></i> GitHub</a>
+                <a href="{% url 'core_directory:api_docs_landing' %}" target="_blank"><i class="bi bi-code-slash"></i> API Documentation</a>
+                <a href="{% url 'core-package-list' %}"><i class="bi bi-list"></i> Browse all cores</a>
+            </div>
         </div>
-        <div class="links-section mb-4">
-            <a href="https://fusesoc.github.io/" target="_blank"><i class="bi bi-book"></i> Documentation</a>
-            <a href="https://github.com/fusesoc/fusesoc-webserver" target="_blank"><i class="bi bi-github"></i> GitHub</a>
-            <a href="{% url 'core_directory:api_docs_landing' %}" target="_blank"><i class="bi bi-code-slash"></i> API Documentation</a>
-            <a href="{% url 'core-package-list' %}"><i class="bi bi-list"></i> Browse all cores</a>
+
+        <div class="desc-section">
+            <h2>Like to publish your cores?</h2>
+            <p>
+                The FuseSoC Package Directory supports several ways to publish your cores:
+            </p>
+                <div class="links-section mb-4">
+                    <a href="https://fusesoc.net/" target="_blank"><i class="bi bi-terminal"></i> FuseSoC-CLI </a>
+                    <a href="{% url 'core_directory:api_docs_landing' %}" target="_blank"><i class="bi bi-code-slash"></i> API </a>
+                    <a href="{% url 'core-publish' %}"><i class="bi bi-window-plus"></i> Web interface </a>
+                <div>
         </div>
     </div>
     <footer class="footer text-center text-muted py-3 small">

--- a/core_directory/tests/web_ui/tests.py
+++ b/core_directory/tests/web_ui/tests.py
@@ -21,6 +21,15 @@ def test_landing_view(client):
     assert response.context["num_vendors"] == 1
 
 @pytest.mark.django_db
+def test_core_publish_view(client):
+    url = reverse('core-publish')  # Use the name from your urls.py
+    response = client.get(url)
+    assert response.status_code == 200
+    # Check that the correct template was used
+    templates = [t.name for t in response.templates]
+    assert 'web_ui/core_publish.html' in templates
+
+@pytest.mark.django_db
 def test_landing_view_two_cores(client):
     vendor = Vendor.objects.create(name="Acme")
     library = Library.objects.create(vendor=vendor, name="Lib1")

--- a/core_directory/views/web_views.py
+++ b/core_directory/views/web_views.py
@@ -15,6 +15,11 @@ def landing(request):
                   }
                 )
 
+def core_publish(request):
+    """Render the page to publish a core."""
+    return render(request, 'web_ui/core_publish.html')
+
+
 def core_package_list(request):
     """Render a list of core packages, optionally filtered by search query."""
     search_query = request.GET.get('search', '')

--- a/project/urls.py
+++ b/project/urls.py
@@ -24,8 +24,9 @@ from django.urls import include, path
 from core_directory.views.web_views import (
     landing,
     core_detail,
-    core_package_list,
     core_detail_by_vlnv,
+    core_package_list,
+    core_publish,
     vendor_list,
     vendor_detail
 )
@@ -33,6 +34,7 @@ from core_directory.views.web_views import (
 urlpatterns = [
 
     path('', landing, name='landing'),
+    path('publish', core_publish, name='core-publish'),
     path('core/<int:pk>/', core_detail, name='core-detail'),
 
     path('cores/', core_package_list, name='core-package-list'),


### PR DESCRIPTION
This PR adds a web interface for publishing FuseSoC cores directly from GitHub repositories.

Key Features:

GitHub Integration:
Users specify a repository and version (latest, tag, or commit). The UI fetches repo details and lists available .core files and their signature status.

Client-side Processing:
JavaScript fetches and parses the selected .core file (and signature, if present) from GitHub. If needed, a provider section is added automatically.

REST API Usage:
Core and signature files are validated and published via the server’s REST API. Errors and validation results are shown in a user-friendly way.

Improved UX:
Enhanced layout, clearer feedback, and a help section guide users through the process.

This streamlines and simplifies core publishing from GitHub, making it more accessible and robust.

Closes #6 