### PR TITLE
Refactors core listing and retrieval API

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,13 @@ All endpoints are under `/api/v1/`:
 |----------------------------|--------|------------------------------------------|
 | `/health/`                 | GET    | API health check                         |
 | `/list/?filter=...`        | GET    | List available core packages             |
-| `/<package_name>/get/`     | GET    | Download a `.core` file                  |
+| `/get/?core=...`           | GET    | Download a `.core` file by VLNV name     |
 | `/validate/`               | POST   | Validate a core file (`multipart/form`)  |
 | `/publish/`                | POST   | Publish a core file to GitHub            |
+
+- **Download (`/get/`)**: Provide the `core` query parameter with the full VLNV (e.g., `acme:lib1:foo:1.0.0`).
+- **Validation and publishing**: Upload core files (and optional signatures) via `multipart/form-data`.
+- **OpenAPI/Swagger docs**: Interactive documentation is available at `/api/v1/docs/swagger/` and `/api/v1/docs/redoc/`.
 
 ---
 

--- a/core_directory/models.py
+++ b/core_directory/models.py
@@ -144,6 +144,19 @@ class CorePackage(UniqueSanitizedNameMixin):
         """
         return bool(self.sig_url)
 
+    @property
+    def sanitized_vlnv(self):
+        """
+        Returns a filesystem- and URL-safe version of the core's VLNV (Vendor:Library:Name:Version),
+        with colons and other problematic characters replaced by underscores.
+        """
+        return (
+            f'{self.project.vendor.sanitized_name}_'
+            f'{self.project.library.sanitized_name}_'
+            f'{self.project.sanitized_name}_'
+            f'{self.sanitized_name}'
+        )
+
     class Meta:
         """Ensure version is unique per project."""
         unique_together = ('project', 'version')

--- a/core_directory/tests/test_urls.py
+++ b/core_directory/tests/test_urls.py
@@ -6,7 +6,7 @@ from django.urls import reverse, resolve
     ("redirect_to_docs", {}, 301, False, "get"),
     ("health_check", {}, 200, False, "get"),
     ("core_list", {}, 200, False, "get"),
-    ("core_get", {"package_name": "example"}, 200, False, "get"),
+    ("core_get", {}, 400, False, "get"),
     ("validate", {}, 400, False, "post"),
     ("publish", {}, 400, False, "post"),
     ("api_docs_landing", {}, 200, False, "get"),

--- a/core_directory/urls.py
+++ b/core_directory/urls.py
@@ -41,7 +41,7 @@ urlpatterns = [
         path('', RedirectView.as_view(url='docs/', permanent=True), name='redirect_to_docs'),
         path('health/', HealthCheckView.as_view(), name='health_check'),
         path('list/', Cores.as_view(), name='core_list'),
-        path('<str:package_name>/get/', GetCore.as_view(), name='core_get'),
+        path('get/', GetCore.as_view(), name='core_get'),
         path('validate/', Validate.as_view(), name='validate'),
         path('publish/', Publish.as_view(), name='publish'),
 

--- a/core_directory/views/api_views.py
+++ b/core_directory/views/api_views.py
@@ -3,6 +3,8 @@ import os
 
 from dataclasses import dataclass
 
+import requests
+
 from django.http import HttpResponse
 from django.views.generic import TemplateView
 
@@ -18,6 +20,7 @@ from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from ..models import CorePackage
 from ..serializers import CoreSerializer
 
 class APIDocsLandingPageView(TemplateView):
@@ -63,10 +66,13 @@ class HealthCheckView(APIView):
         return Response({'status': 'ok'}, status=200)
 
 class Cores(APIView):
-    """Endpoint for listing all available cores."""
+    """Endpoint for listing all available core packages in the database."""
     @extend_schema_with_429(
         summary='List all cores',
-        description='Returns a list of all cores available in FuseSoC-PD.',
+        description=(
+            'turns a list of all core packages available in FuseSoC-PD, '
+            'optionally filtered by a keyword in the VLNV name.'
+        ),
         responses={200: OpenApiResponse(description='List of all available cores')},
         parameters=[
             OpenApiParameter(
@@ -78,96 +84,86 @@ class Cores(APIView):
             )
         ]
     )
-    def get(self, request):
-        """List all available cores, optionally filtered by a keyword.
+    def get(self, request, *args, **kwargs):
+        """List all available core packages, optionally filtered by a keyword.
 
         Returns:
-            Response: List of core names or error message.
+            Response: List of core VLNV names or error message.
         """
-        repo_name = os.getenv('GITHUB_REPO')
-
         filter_keyword = request.query_params.get('filter', '')
 
-        try:
-            # Initialize GitHub client
-            g = Github(auth=GitHubAuthToken(os.getenv('GITHUB_ACCESS_TOKEN')))
-            repo = g.get_repo(repo_name)
+        available_cores = (
+            CorePackage.objects
+            .filter(vlnv_name__icontains=filter_keyword)
+            .order_by('vlnv_name')
+            .values_list('vlnv_name', flat=True)
+        )
+        return Response(available_cores, status=status.HTTP_200_OK)
 
-            contents = repo.get_contents('')
-            core_files = [
-                content.path.removesuffix('.core')
-                for content in contents
-                if content.type == 'file' and content.path.endswith('.core')
-            ]
-
-            # Apply filter if filter_keyword is provided
-            if filter_keyword:
-                core_files = [core for core in core_files if filter_keyword.lower() in core.lower()]
-
-            return Response(core_files, status=status.HTTP_200_OK)
-        except GithubException as err:
-            # Handle specific GitHub API errors
-            return Response({'error': f'GitHub error: {err.data}'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 class GetCore(APIView):
-    """Endpoint for downloading a FuseSoC core package."""
+    """Endpoint for downloading a FuseSoC core package file by VLNV name."""
     @extend_schema_with_429(
-    summary='Download a FuseSoC Core Package',
-    description='Provide the FuseSoC Core Package as a YAML file to the user.',
-    parameters=[
-        OpenApiParameter(
-            name='package_name',
-            description='The name of the FuseSoC Core Package',
-            required=True,
-            type=OpenApiTypes.STR,
-            location=OpenApiParameter.PATH
-        )
-    ],
-    responses={
-        200: OpenApiResponse(description='FuseSoC Core Package successfully retrieved'),
-        404: OpenApiResponse(description='FuseSoC Core Package not found')
-    }
+        summary='Download a FuseSoC Core Package',
+        description='Provide the FuseSoC Core Package as a .core file to the user.',
+        parameters=[
+            OpenApiParameter(
+                name='core',
+                description='Downloads the `.core` file for a given core package (identified by its VLNV name).',
+                required=True,
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY
+            )
+        ],
+        responses={
+            200: OpenApiResponse(description='FuseSoC Core Package successfully retrieved'),
+            404: OpenApiResponse(description='FuseSoC Core Package not found')
+        }
     )
-    def get(self, request, package_name):
-        """Download a FuseSoC core package by name.
+    def get(self, request):
+        """Download a FuseSoC core package file by VLNV name.
 
-        Args:
-            package_name (str): The name of the core package to download.
+        Query Parameters:
+            core (str): The VLNV name of the core package to download (e.g., 'acme:lib1:foo:1.0.0').
 
         Returns:
-            HttpResponse: The core file as an attachment, or error message.
+            HttpResponse: The core file as an attachment, or error message if not found.
         """
-        repo_name = os.getenv('GITHUB_REPO')
+        requested_core_vlnv = request.query_params.get('core', '')
+
+        if not requested_core_vlnv:
+            return Response(
+                {'error': 'Missing required "core" query parameter.'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
 
         try:
-            # Initialize GitHub client
-            g = Github(auth=GitHubAuthToken(os.getenv('GITHUB_ACCESS_TOKEN')))
-            repo = g.get_repo(repo_name)
+            core_object = CorePackage.objects.get(vlnv_name=requested_core_vlnv)
 
-            contents = contents = repo.get_contents(f'{package_name}.core')
-            # Decode the content from base64
-            file_content = contents.decoded_content.decode('utf-8')
-
-            response = HttpResponse(file_content, content_type='application/octet-stream')
-            response['Content-Disposition'] = f'attachment; filename={package_name}.core'
-            return response
-        except GithubException as err:
-            if err.status == 404:
-                return Response(
-                    {'error': f'FuseSoC Core Package {package_name} not found'},
-                    status=status.HTTP_404_NOT_FOUND
-                )
-            return Response({'error': f'GitHub error: {err.data}'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-
+            requested_file = requests.get(core_object.core_url, timeout=10)
+            if requested_file.status_code == 200:
+                response = HttpResponse(requested_file.content, content_type='application/octet-stream')
+                response['Content-Disposition'] = f'attachment; filename={core_object.sanitized_vlnv}.core'
+                return response
+            return Response(
+                {'error': f'FuseSoC Core Package {requested_core_vlnv} not found.'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+        except CorePackage.DoesNotExist:
+            return Response(
+                {'error': f'FuseSoC Core Package {requested_core_vlnv} not available.'},
+                status=status.HTTP_404_NOT_FOUND
+            )
 class Publish(APIView):
-    """Endpoint for publishing a core file."""
+    """Endpoint for publishing a new core file to FuseSoC Package Directory."""
     parser_classes = (MultiPartParser, FormParser)
 
     @extend_schema_with_429(
         summary='Publish a core file',
         description=(
-            'Validates and publish a core file to github. '
-            'The core file should be uploaded as a multipart/form-data request.'
+            'Validates and publishes a core file to FuseSoC Package Directory. '
+            'The core file should be uploaded as a multipart/form-data request. '
+            'On success, the directory is updated with the new core package.'
         ),
         request={
             'multipart/form-data': {
@@ -190,12 +186,12 @@ class Publish(APIView):
             }
         },
         responses={
-            200: OpenApiResponse(description='Core file is valid'),
+            201: OpenApiResponse(description='Core published successfully'),
             400: OpenApiResponse(description='Error message indicating why the validation failed')
         }
     )
     def post(self, request, *args, **kwargs):
-        """Validate and publish a core file to GitHub.
+        """Validate and publish a core file to FuseSoC Package Directory.
 
         Returns:
             Response: Success message or error message.
@@ -245,6 +241,15 @@ class Publish(APIView):
         serializer = CoreSerializer(data=request.data)
 
         if serializer.is_valid():
+
+            vlnv_name = serializer.validated_data['vlnv_name']
+            # Check if a core with this VLNV already exists in the database
+            if CorePackage.objects.filter(vlnv_name=vlnv_name).exists():
+                return Response(
+                    {'error': f'Core \'{vlnv_name}\' already exists in FuseSoC Package Directory.'},
+                    status=status.HTTP_409_CONFLICT
+                )
+
             core_data = CoreData(
                 vlnv_name = serializer.validated_data['vlnv_name'],
                 core_file = serializer.validated_data['core_file'],
@@ -264,7 +269,7 @@ class Publish(APIView):
                 _ = repo.get_contents(core_data.core_file_name)
                 # The core already exists -> do not create again
                 return Response(
-                    {'message': f'Core \'{core_data.vlnv_name}\' already exists in the database.'},
+                    {'message': f'Core \'{core_data.vlnv_name}\' already exists in FuseSoC Package Directory.'},
                     status=status.HTTP_409_CONFLICT
                 )
             except (UnknownObjectException, IndexError, GithubException):
@@ -307,7 +312,7 @@ class Publish(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 class Validate(APIView):
-    """Endpoint for validating a core file."""
+    """Endpoint for validating a core file (before publishing)."""
     @extend_schema_with_429(
         summary='Validate a core file',
         description=(
@@ -338,7 +343,7 @@ class Validate(APIView):
         }
     )
     def post(self, request, *args, **kwargs):
-        """Validate a core file against a predefined JSON schema.
+        """Validate a core file before publishing.
 
         Returns:
             Response: Validation success or error message.


### PR DESCRIPTION
Streamlines the core listing and retrieval endpoints to use the database as the source of truth instead of Github.

- Modifies the `/list/` endpoint to retrieve core packages from the database, allowing for filtering by VLNV name.
- Changes the `/get/` endpoint to fetch core files directly via a URL stored in the database, identified by the VLNV name.
- Adds tests for core listing, retrieval, and publishing endpoints.

This change improves performance, simplifies the codebase, and reduces dependency on the Github API.

Closes #14 